### PR TITLE
Update README.md to reflect workflow changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # GodotSP
-This is our custom build of the godot engine meant for internal use thus not ducmented.
+This is our custom build of the godot engine meant for internal use thus not documented.
 
-Nightly links:
+### Nightly links:
+#### Linux:
 - [Linux Editor](https://nightly.link/WeaselGames/godotSP/workflows/linux/master/linux-editor.zip)
-- [Linux Templates](https://nightly.link/WeaselGames/godotSP/workflows/linux/master/linux-templates.zip)
-- [Windows Editor](https://nightly.link/WeaselGames/godotSP/workflows/windows/master/windows-editor.zip)
-- [Windows Templates](https://nightly.link/WeaselGames/godotSP/workflows/windows/master/windows-templates.zip)
-- [MacOS Templates](https://nightly.link/WeaselGames/godotSP/workflows/macos/master/macos-templates.zip)
+- [Linux Template Debug](https://nightly.link/WeaselGames/godotSP/workflows/linux/master/linux-template-debug.zip)
+- [Linux Template Release](https://nightly.link/WeaselGames/godotSP/workflows/linux/master/linux-template-release.zip)
 
+#### Windows:
+- [Windows Editor](https://nightly.link/WeaselGames/godotSP/workflows/windows/master/windows-editor.zip)
+- [Windows Template Debug](https://nightly.link/WeaselGames/godotSP/workflows/windows/master/windows-template-debug.zip)
+- [Windows Template Release](https://nightly.link/WeaselGames/godotSP/workflows/windows/master/windows-template-release.zip)
+
+#### macOS:
+- [macOS Template Debug](https://nightly.link/WeaselGames/godotSP/workflows/macos/master/macos-template-debug.zip)
+- [macOS Template Release](https://nightly.link/WeaselGames/godotSP/workflows/macos/master/macos-template-release.zip)


### PR DESCRIPTION
Debug and Release templates are now in different workflows, therefore needs to have separate links.

Also fixed some spelling mistakes and separated links into OS categories.