### PR TITLE
Use universal bins and app bundle on macOS builds

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,13 +22,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: MacOS Template Debug
-            cache-name: macos-template-debug
-            target: template_debug
+          - name: macOS Editor
+            cache-name: macos-editor-sp
+            editor: true
 
-          - name: MacOS Template Release
-            cache-name: macos-template-release
-            target: template_release
+          - name: macOS Template
+            cache-name: macos-template-sp
+            template: true
 
     steps:
       - name: Checkout Godot
@@ -99,18 +99,53 @@ jobs:
           python --version
           scons --version
 
-      - name: Compilation
+      - name: Compilation (editor)
+        if: ${{ matrix.editor }}
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
           BUILD_NAME: "SP"
         run: |
-          scons platform=macos target=${{ matrix.target }} extra_suffix=SP
+          scons platform=macos arch=x86_64 target=editor
+          scons platform=macos arch=arm64 target=editor
+
+      - name: Compilation (template)
+        if: ${{ matrix.template }}
+        env:
+          SCONS_CACHE: ${{github.workspace}}/.scons_cache/
+          BUILD_NAME: "SP"
+        run: |
+          scons platform=macos arch=x86_64 target=template_debug
+          scons platform=macos arch=arm64 target=template_debug
+          scons platform=macos arch=x86_64 target=template_release
+          scons platform=macos arch=arm64 target=template_release
+
+      - name: Bundle architectures and pack (editor)
+        if: ${{ matrix.editor }}
+        run: |
+          lipo -create bin/godot.macos.editor.x86_64 bin/godot.macos.editor.arm64 -output bin/godot.macos.editor.universal
+          strip bin/godot.macos.editor.universal
+          mkdir app
+          cp -r misc/dist/macos_tools.app app/GodotSP.app
+          mkdir -p app/GodotSP.app/Contents/MacOS
+          cp bin/godot.macos.editor.universal app/GodotSP.app/Contents/MacOS/godot.macos.editor.universal
+          chmod +x app/GodotSP.app/Contents/MacOS/godot.macos.editor.universal
+
+      - name: Bundle architectures and pack (template)
+        if: ${{ matrix.template }}
+        run: |
+          lipo -create bin/godot.macos.template_debug.x86_64 bin/godot.macos.template_debug.arm64 -output bin/godot.macos.template_debug.universal
+          lipo -create bin/godot.macos.template_release.x86_64 bin/godot.macos.template_release.arm64 -output bin/godot.macos.template_release.universal
+          strip bin/godot.*
+          mkdir app
+          cp -r misc/dist/macos_template.app app/macos_template.app
+          mkdir -p app/macos_template.app/Contents/MacOS
+          cp bin/godot.macos.template_debug.universal app/macos_template.app/Contents/MacOS/godot.macos.template_debug.universal
+          cp bin/godot.macos.template_release.universal app/macos_template.app/Contents/MacOS/godot.macos.template_release.universal
+          chmod +x app/macos_template.app/Contents/MacOS/godot.macos.template_debug.universal
+          chmod +x app/macos_template.app/Contents/MacOS/godot.macos.template_release.universal
 
       - name: Prepare artifact
-        run: |
-          strip bin/godot.*
-          chmod +x bin/godot.*
-      - uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2
         with:
           name: ${{matrix.cache-name}}
-          path: bin
+          path: app

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ This is our custom build of the godot engine meant for internal use thus not doc
 - [Windows Template Release](https://nightly.link/WeaselGames/godotSP/workflows/windows/master/windows-template-release.zip)
 
 #### macOS:
-- [macOS Template Debug](https://nightly.link/WeaselGames/godotSP/workflows/macos/master/macos-template-debug.zip)
-- [macOS Template Release](https://nightly.link/WeaselGames/godotSP/workflows/macos/master/macos-template-release.zip)
+- [macOS Editor](https://nightly.link/WeaselGames/godotSP/workflows/macos/master/macos-editor-sp.zip)
+- [macOS Template (Debug and Release)](https://nightly.link/WeaselGames/godotSP/workflows/macos/master/macos-template-sp.zip)


### PR DESCRIPTION
Improvements to macOS builds

- Greatly approaches our binary distribution to how Godot builds are built, packed and distributed;

- Enables macOS editor builds;

- Changes the download links to reflect the new distribution;

Closes #4 