### PR TITLE
Bump to RC6 & Switch upstream to fork

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Checkout Godot
         uses: actions/checkout@v3
         with:
-          repository: godotengine/godot
-          ref: 6296b46008fb8d8e5cb9b60af05fa1ea26b8f600
+          repository: WeaselGames/godot
+          ref: 26ca2ee80554e8171456e341407d945ac3a4d662
 
       - name: Checkout LuaAPI
         uses: actions/checkout@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Checkout Godot
         uses: actions/checkout@v3
         with:
-          repository: godotengine/godot
-          ref: 6296b46008fb8d8e5cb9b60af05fa1ea26b8f600
+          repository: WeaselGames/godot
+          ref: 26ca2ee80554e8171456e341407d945ac3a4d662
 
       - name: Checkout LuaAPI
         uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Checkout Godot
         uses: actions/checkout@v3
         with:
-          repository: godotengine/godot
-          ref: 6296b46008fb8d8e5cb9b60af05fa1ea26b8f600
+          repository: WeaselGames/godot
+          ref: 26ca2ee80554e8171456e341407d945ac3a4d662
 
       - name: Checkout LuaAPI
         uses: actions/checkout@v3


### PR DESCRIPTION
Since https://github.com/godotengine/godot/issues/59912 was moved to the 4.x tag I have switched the upstream for Godot to a fork. The only change in our fork is all of the `!material` conditions in material_storage.cpp have been changed to instead silently fail. This means we can work on the project without getting spammed with 800+ error messages. Important to note that this could cause some legitimate errors to be suppressed.